### PR TITLE
feat: add base css generator and extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/css

--- a/lib/css/build.js
+++ b/lib/css/build.js
@@ -1,0 +1,71 @@
+import {mkdirSync, writeFileSync} from 'node:fs'
+import {join} from 'node:path'
+import prettier from 'prettier'
+import {minify} from 'csso'
+import {variants} from '../../index.js'
+import {colorExtractor} from './color-extractor.js'
+
+const OUT_DIR = './css'
+const TEMPLATE_KEY = '{{template}}'
+const STYLE_VARIABLE_PREFIX = 'rose-'
+const styleSheetTemplate = `
+    :root{
+        ${TEMPLATE_KEY}
+    }
+`
+
+let styleSheet = ``
+
+// ANSI Color defs
+const bold = (s) => '\u001B[1m' + s
+const yellow = (s) => '\u001B[33m' + s
+const green = (s) => '\u001B[32m' + s
+const white = (s) => '\u001B[37m' + s
+const reset = (s) => '\u001B[0m' + s + '\u001B[0m'
+
+const pathToCSSVariable = (path) => {
+	return `--${path}`
+}
+
+const varToStyleString = (variable, value) => {
+	return `${variable}:${value};`
+}
+
+const appendToStylesheet = (cssString) => {
+	if (!styleSheet) {
+		styleSheet = styleSheetTemplate
+	}
+
+	return styleSheet.replace(
+		new RegExp(TEMPLATE_KEY),
+		`${cssString}\n{{template}}`
+	)
+}
+
+const purgeTemplate = (template) => {
+	return template.replace(new RegExp(TEMPLATE_KEY), '')
+}
+
+function build() {
+	const _variants = colorExtractor(variants)
+	for (const variant of _variants) {
+		const colorPath = `${STYLE_VARIABLE_PREFIX}${variant.path}`
+		const cssVarName = pathToCSSVariable(colorPath)
+		const cssVarString = varToStyleString(cssVarName, variant.color)
+		styleSheet = appendToStylesheet(cssVarString)
+	}
+
+	styleSheet = purgeTemplate(styleSheet)
+	const cleanedStyles = prettier.format(styleSheet, {parser: 'css'})
+
+	mkdirSync(OUT_DIR, {recursive: true})
+	writeFileSync(join(OUT_DIR, 'rose-pine.css'), cleanedStyles)
+	writeFileSync(join(OUT_DIR, 'rose-pine.min.css'), minify(cleanedStyles).css)
+
+	const odt = reset(bold(white(OUT_DIR)))
+	const prmt = yellow('>>')
+	const message = green('CSS files fenerated to the dir')
+	console.log(`${prmt} ${message} ${odt}`)
+}
+
+build()

--- a/lib/css/color-extractor.js
+++ b/lib/css/color-extractor.js
@@ -1,0 +1,23 @@
+import {paramCase} from 'param-case'
+
+export function colorExtractor(source, visitedPath = '') {
+	if (typeof source === 'string') {
+		return {color: source, path: visitedPath}
+	}
+
+	let colorMap = []
+
+	for (const key of Object.keys(source)) {
+		let pathKey = paramCase(visitedPath)
+		if (key !== 'hex') {
+			pathKey += '-' + paramCase(key)
+		}
+
+		const value = colorExtractor(source[key], pathKey)
+		colorMap = Array.isArray(value)
+			? [...colorMap, ...value]
+			: [...colorMap, value]
+	}
+
+	return colorMap
+}

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
 	},
 	"scripts": {
 		"build": "npm test",
+		"build:css": "node lib/css/build.js",
 		"test": "xo && ava",
 		"release": "np",
 		"prepare": "npm run build"
 	},
 	"files": [
+		"css/",
 		"index.js",
 		"index.d.ts"
 	],
@@ -37,8 +39,10 @@
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",
+		"csso": "^5.0.2",
 		"np": "^7.6.0",
-		"prettier": "^2.5.0",
+		"param-case": "^3.0.4",
+		"prettier": "^2.5.1",
 		"xo": "^0.47.0"
 	},
 	"prettier": {


### PR DESCRIPTION
The original as another step where it generates a small report of the css static file sizes. 
I've not added that in this particular request. Let me know if you'd like that

## What it does 
1. Adds a color extraction function to browse through the structure to look for colors strings  (depends on the decision of keeping colors as string, any change to that will need a change in the extractor)
2. Adds a simple build function that writes the above result into a `css` file template